### PR TITLE
Fix TN state misspelling

### DIFF
--- a/fixtures/states.csv
+++ b/fixtures/states.csv
@@ -8,7 +8,7 @@ GA,Georgia,3/1/2016,Primary,Open
 MA,Massachusetts,3/1/2016,Primary,Mixed
 MN,Minnesota,3/1/2016,Caucus,Open
 OK,Oklahoma,3/1/2016,Primary,Open
-TN,Tennasee,3/1/2016,Primary,Open
+TN,Tennessee,3/1/2016,Primary,Open
 TX,Texas,3/1/2016,Primary,Open
 VT,Vermont,3/1/2016,Primary,Open
 VA,Virginia,3/1/2016,Primary,Open


### PR DESCRIPTION
Prior to this change, the state fixture for Tenn**e**s**s**ee was spelled “Tenn**a**see”.
