### PR TITLE
Create additional options for report age

### DIFF
--- a/src/client/components/report/form/timeselect.jsx
+++ b/src/client/components/report/form/timeselect.jsx
@@ -8,7 +8,9 @@ const TimeSelect = () => (
       <option value="30">30 minutes ago</option>
       <option value="60">An hour ago</option>
       <option value="90">An hour and a half ago</option>
-      <option value="120">Two or more hours ago</option>
+      <option value="120">Two hours ago</option>
+      <option value="150">Two and a half hours ago</option>
+      <option value="210">Three or more hours ago</option>
     </select>
   </label>
 );


### PR DESCRIPTION
This update adds two additional options to the `report_age` menu, and updates the “two hours” option. The modified/new options:
- (2) Two hours ago.
- (2.5) Two and a half hours ago.
- (3.5) Three or more hours ago (see [here](https://github.com/Bernie-2016/votetracker/issues/42#issuecomment-190592531) for explanation).

Closes #42
